### PR TITLE
Prep for 6.2.11-rc-2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
-## 6.2.11-rc-2 TBD
+
+## 6.2.11-rc-2 (2017-02-11)
 
 ### Changed
 
@@ -12,6 +13,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ### Removed
 
 - Removed PHPDebugger.inc, PHPDebugger.java, see [#23](https://github.com/belgattitude/php-java-bridge/issues/23) and [#16](https://github.com/belgattitude/php-java-bridge/issues/16)
+- `maven publish` - removed dependency of log4j in pom.xml.
+ 
+
+### Fixed
+
+- `maven publish` - Fixed dependency scope of servlet-api to 'provided', see [#24](https://github.com/belgattitude/php-java-bridge/issues/24)
+- `maven publish` - Duplicate inclusion of servlet-api in pom dependencies (no side effect - cleanup doubles in gradle)
 
 
 ## 6.2.11-rc-1 (2017-02-06)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
-## UNRELEASED
+## 6.2.11-rc-2 TBD
+
+### Changed
+
+- License from MIT to Apache 2.0, see [#10](https://github.com/belgattitude/php-java-bridge/issues/10)
+
+### Removed
+
+- Removed PHPDebugger.inc, PHPDebugger.java, see [#23](https://github.com/belgattitude/php-java-bridge/issues/23) and [#16](https://github.com/belgattitude/php-java-bridge/issues/16)
+
 
 ## 6.2.11-rc-1 (2017-02-06)
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -31,7 +31,7 @@ The source code for soluble php-java-bridge is available at:
 
 ## MIT License
 
-Several parts of the source code is distributed under the MIT
+Several parts of the source code are distributed under the MIT
 license, which is reproduced below:
 
 > Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,28 +1,54 @@
-MIT License 
+# License
 
-Copyright (c) 2017 - Jost Boekemeier
-                   - Andre Felipe Machado
-                   - Sam Ruby
-                   - Kai Londenberg
-                   - Nandika Jayawardana
-                   - Sanka Samaranayake
-                   - Christian P. Lerch
-                   - Sébastien Vanvelthem
+Soluble php-java-bridge is free software, licensed under the Apache License, Version 2.0 (the
+"License"). Commercial and non-commercial use are permitted in compliance with
+the License.
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+Copyright (c) 2017-present Jost Boekemeier, Sébastien Vanvelthem, Christian P. Lerch and the
+[contributors](https://github.com/belgattitude/php-java-bridge/blob/master/CREDITS.md).
+All rights reserved.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+You may obtain a copy of the License at:
+[http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+
+As stated in Section 7, "Disclaimer of Warranty," of the License:
+
+> Licensor provides the Work (and each Contributor provides its Contributions)
+> on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+> express or implied, including, without limitation, any warranties or
+> conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+> PARTICULAR PURPOSE. You are solely responsible for determining the
+> appropriateness of using or redistributing the Work and assume any risks
+> associated with Your exercise of permissions under this License.
+
+The source code for soluble php-java-bridge is available at:
+
+[https://github.com/belgattitude/php-java-bridge](https://github.com/belgattitude/php-java-bridge)
+
+# Additional and third-party licences
+
+## MIT License
+
+Several parts of the source code is distributed under the MIT
+license, which is reproduced below:
+
+> Permission is hereby granted, free of charge, to any person obtaining a copy
+> of this software and associated documentation files (the "Software"), to deal
+> in the Software without restriction, including without limitation the rights
+> to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+> copies of the Software, and to permit persons to whom the Software is
+> furnished to do so, subject to the following conditions:
+>
+> The above copyright notice and this permission notice shall be included in all
+> copies or substantial portions of the Software.
+>
+> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+> IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+> FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+> AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+> LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+> OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+> SOFTWARE.
+

--- a/README.md
+++ b/README.md
@@ -20,24 +20,19 @@ look to those projects:
 
 Latest version 6.2.1 has been released long ago but, AFAIK, proved stable and mature. Here are some plans and statuses of the fork:  
 
-- [x] Migration from CVS to github
+- [x] Migration from sourceforge CVS to github.
 - [x] Support for PHP7 and rewrite of the client `Java.inc`, see [soluble-japha](https://github.com/belgattitude/soluble-japha)
-- [x] Test and update of the build file, Tomcat8 and JDK8.
-- [x] Releasing a new version, with downloadable releases on Github (6.2.10)
-- [x] Prepare a starter project with servlet 3.0 spec support, see [pjb-starter-gradle](https://github.com/belgattitude/pjb-starter-gradle).
-- [x] Preliminary support and conversion to gradle (with ant tasks).
-- [x] Regenerate and host [Java API doc](http://docs.soluble.io/php-java-bridge/api)
-- [ ] Port and convert most of `./test.php5` in [soluble-japha](https://github.com/belgattitude/soluble-japha).
-- [ ] License issue; MIT or GPL (website indicates MIT while CVS GPL) ? Try to contact original developers.
-- [ ] Remove dependency of php in build scripts (should be possible to build without php) 
+- [x] Gradle support for project builds.
+- [x] Ensure support of Tomcat 8+, JDK 8.
+- [x] Prepare a starter project to customize builds, see [pjb-starter-gradle](https://github.com/belgattitude/pjb-starter-gradle).
+- [x] Update namespace to `io.soluble.pjb` and host [Java API doc](http://docs.soluble.io/php-java-bridge/api)
+- [x] License to Apache 2.0 and drop GPL code, see [#10](https://github.com/belgattitude/php-java-bridge/issues/10)
+- [x] Artifact published and available on maven central. 
+- [x] Clean-up of obsolete code and unused resources.
+- [x] Port and convert most of `./test.php5` in [soluble-japha](https://github.com/belgattitude/soluble-japha).
 - [ ] Deprecate and remove completely the `Java.inc` client.
-- [x] Publish on maven (need help - must be made after removal of php dependency)
-- [x] Removal of obsolete code and resources.
 - [ ] Security review and safe practices.
-- [ ] Write JUnit tests
-- [ ] Start refactorings and improve ;)
 - [ ] Documentation (always a wip)
-
 
 Please **[participate in the discussion for future ideas here](https://github.com/belgattitude/php-java-bridge/issues/6)**. 
 
@@ -137,8 +132,7 @@ For rebuilding the older Java.inc and launchers:
 $ gradle genClean -Dphp_exec=php5.6
 $ gradle genAll -Dphp_exec=php5.6
 ```
-                                                         
-                                                        
+                                                                                                                 
 ## Usage
 
 ### Deploy

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Build Status](https://travis-ci.org/belgattitude/php-java-bridge.svg?branch=master)](https://travis-ci.org/belgattitude/php-java-bridge)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 (Develop branch: [![Build Status](https://travis-ci.org/belgattitude/php-java-bridge.svg?branch=develop)](https://travis-ci.org/belgattitude/php-java-bridge))
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -115,12 +115,16 @@ task javadocJar(type: Jar, dependsOn: javadoc) {
 }
 
 
+artifacts {
+    archives jar
+    archives sourcesJar
+    archives javadocJar
+}
+
 signing {
     required { signatory != null && project.ext.isReleaseVersion }
     sign configurations.archives
 }
-
-
 
 publishing {
     repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -10,8 +10,8 @@ apply plugin: 'maven-publish'
 
 group = "io.soluble.pjb"
 archivesBaseName = 'php-java-bridge'
-//version = "6.2.11-rc-2"
-version = "6.2.11-SNAPSHOT"
+version = "6.2.11-rc-2"
+//version = "6.2.11-SNAPSHOT"
 description = "PHPJavaBridge server (soluble fork)"
 
 ext {
@@ -201,6 +201,17 @@ publishing {
                     }
                 }
 
+            }
+
+            // providedCompile -> provided scope
+            pom.withXml {
+                asNode().dependencies.'*'.findAll() {
+                    it.scope.text() == 'runtime'  && project.configurations.providedCompile.allDependencies.find { dep ->
+                        dep.name == it.artifactId.text()
+                    }
+                }.each() {
+                    it.scope*.value = 'provided'
+                }
             }
 
             // Sign the pom.xml and artifacts.

--- a/build.gradle
+++ b/build.gradle
@@ -61,13 +61,12 @@ repositories {
 
 dependencies {
 
-    runtime('log4j:log4j:1.2.17')
+    testRuntime('log4j:log4j:1.2.17')
     testCompile('junit:junit:3.8.2')    // the test code still uses this junit API
 
     def tomcatVersion = '7.0.73'
 
     providedCompile('javax.servlet:javax.servlet-api:3.0.1')
-    //compile('javax.servlet:javax.servlet-api:3.0.1')
 
     tomcat(
             "org.apache.tomcat.embed:tomcat-embed-core:${tomcatVersion}",
@@ -77,6 +76,7 @@ dependencies {
         exclude group: 'org.eclipse.jdt.core.compiler', module: 'ecj'
     }
 }
+
 
 // When testing you can specify your local PHP executable as a system property with
 // -Dphp_exec=/path/to/php-executabale on the Gradle command line
@@ -114,16 +114,13 @@ task javadocJar(type: Jar, dependsOn: javadoc) {
     from javadoc.destinationDir
 }
 
-artifacts {
-    archives jar
-    archives sourcesJar
-    archives javadocJar
-}
 
 signing {
     required { signatory != null && project.ext.isReleaseVersion }
     sign configurations.archives
 }
+
+
 
 publishing {
     repositories {
@@ -203,15 +200,33 @@ publishing {
 
             }
 
-            // providedCompile -> provided scope
+            //
             pom.withXml {
-                asNode().dependencies.'*'.findAll() {
+
+                Node pomNode = asNode()
+
+                // Fix the providedCompile('javax.servlet:javax.servlet-api:3.0.1') that
+                // was resolved as 'runtime' - instead put it as provided
+                // And add optional to true, as the standalone server is still supported
+                pomNode.dependencies.'*'.findAll() {
                     it.scope.text() == 'runtime'  && project.configurations.providedCompile.allDependencies.find { dep ->
                         dep.name == it.artifactId.text()
                     }
                 }.each() {
                     it.scope*.value = 'provided'
+                    it.appendNode('optional', true)
                 }
+
+                // Fix the duplicate inclusion og
+                // providedCompile('javax.servlet:javax.servlet-api:3.0.1') dep
+                int i = 0;
+                Collection servletApiDeps = pomNode.dependencies.'*'.findAll() {
+                    it.artifactId.text() == 'javax.servlet-api' && i > 1
+                    i++;
+                }.each() {
+                    it.parent().remove(it)
+                }
+
             }
 
             // Sign the pom.xml and artifacts.

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ apply plugin: 'maven-publish'
 
 group = "io.soluble.pjb"
 archivesBaseName = 'php-java-bridge'
-//version = "6.2.11-rc-1"
+//version = "6.2.11-rc-2"
 version = "6.2.11-SNAPSHOT"
 description = "PHPJavaBridge server (soluble fork)"
 

--- a/build.gradle
+++ b/build.gradle
@@ -175,20 +175,20 @@ publishing {
                     }
                     appendNode('licenses').with {
                         appendNode('license').with {
-                            appendNode('name', 'The MIT License (MIT)')
-                            appendNode('url', 'https://opensource.org/licenses/MIT')
+                            appendNode('name', 'The Apache Software License, Version 2.0')
+                            appendNode('url', 'http://www.apache.org/licenses/LICENSE-2.0.txt')
                         }
                     }
                     appendNode('organization').with {
-                        appendNode('name', 'Soluble')
-                        appendNode('url', 'http://soluble.io')
+                        appendNode('name', 'php-java-bridge')
+                        appendNode('url', 'https://github.com/belgattitude/php-java-bridge')
                     }
                     appendNode('developers').with {
                         appendNode('developer').with {
                             //appendNode('id', 'belgattitude')
                             appendNode('name', 'Sébastien Vanvelthem')
                             appendNode('email', 'belgattitude@gmail.com')
-                            appendNode('organization', 'Soluble')
+                            appendNode('organization', 'soluble.io')
                             appendNode('organizationUrl', 'https://github.com/belgattitude')
                         }
                         appendNode('developer').with {

--- a/src/main/java/io/soluble/pjb/bridge/Util.java
+++ b/src/main/java/io/soluble/pjb/bridge/Util.java
@@ -80,10 +80,6 @@ public final class Util {
      */
     public static Class JAVA_INC;
     /**
-     * The java/Java.inc code
-     */
-    public static Class PHPDEBUGGER_PHP;
-    /**
      * The java/JavaProxy.php code
      */
     public static Class JAVA_PROXY;
@@ -307,9 +303,6 @@ public final class Util {
 
         try {
             JAVA_INC = Class.forName("io.soluble.pjb.bridge.JavaInc");
-        } catch (ClassNotFoundException e) {/*ignore*/}
-        try {
-            PHPDEBUGGER_PHP = Class.forName("io.soluble.pjb.bridge.PhpDebuggerPHP");
         } catch (ClassNotFoundException e) {/*ignore*/}
         try {
             JAVA_PROXY = Class.forName("io.soluble.pjb.bridge.JavaProxy");

--- a/src/main/java/io/soluble/pjb/servlet/ContextLoaderListener.java
+++ b/src/main/java/io/soluble/pjb/servlet/ContextLoaderListener.java
@@ -355,20 +355,6 @@ public class ContextLoaderListener implements javax.servlet.ServletContextListen
             } catch (Exception e) {
                 e.printStackTrace();
             }
-/* no longer part of the PHP/Java Bridge
-        File phpDebuggerFile = new File (javaDir, "PHPDebugger.php");
-	    try {
-		if (!phpDebuggerFile.exists()) {
-		    Field f = Util.PHPDEBUGGER_PHP.getField("bytes");
-		    byte[] buf = (byte[]) f.get(Util.PHPDEBUGGER_PHP);
-		    OutputStream out = new FileOutputStream (phpDebuggerFile);
-		    out.write(buf);
-		    out.close();
-		}
-	    } catch (Exception e) {
-		e.printStackTrace();
-	    }
-*/
             File javaProxyFile = new File(javaDir, "JavaProxy.php");
             try {
                 if (!javaProxyFile.exists()) {


### PR DESCRIPTION
## 6.2.11-rc-2 (2017-02-11)

### Changed

- License from MIT to Apache 2.0, see [#10](https://github.com/belgattitude/php-java-bridge/issues/10)

### Removed

- Removed PHPDebugger.inc, PHPDebugger.java, see [#23](https://github.com/belgattitude/php-java-bridge/issues/23) and [#16](https://github.com/belgattitude/php-java-bridge/issues/16)
- `maven publish` - removed dependency of log4j in pom.xml.
 

### Fixed

- `maven publish` - Fixed dependency scope of servlet-api to 'provided', see [#24](https://github.com/belgattitude/php-java-bridge/issues/24)
- `maven publish` - Duplicate inclusion of servlet-api in pom dependencies (no side effect - cleanup doubles in gradle)
