### PR TITLE
Draft: Upgrade gradle-wrapper to version 5.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -290,13 +290,5 @@ model {
 
 task install(dependsOn: publishToMavenLocal)
 
-configure(rootProject) {
 
-    task wrapper(type: Wrapper) {
-        description = 'Generates gradlew and gradlew.bat scripts'
-        gradleVersion = '4.10'
-        //jarFile = "${project.projectDir}/.infra/gradle/gradle-wrapper.jar"
-    }
-
-}
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.0-bin.zip


### PR DESCRIPTION
Closes #63

This PR upgrades gradle-wrapper version to 5.0, allowing the project to be built using JDK 11.
It also removes [deprecated built-in task overwrite](https://docs.gradle.org/4.8/release-notes.html#overwriting-gradle's-built-in-tasks). Gradle-wrrapper version should now be maintained only in `./gradle/wrapper/gradle-wrapper.properties`

